### PR TITLE
Run Playwright CI inside the official Playwright container

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,12 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    # Browsers + system deps are pre-installed in this image, so there is no
+    # flaky "playwright install" download step to hang. Keep the tag in sync
+    # with the @playwright/test version in package.json.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -16,20 +22,8 @@ jobs:
       - uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install Playwright browser (chromium)
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 8
-        run: pnpm exec playwright install chromium
-      - name: Install Playwright system dependencies
-        run: pnpm exec playwright install-deps chromium
       - name: Run Playwright tests
-        run: npx playwright test
+        run: pnpm exec playwright test
         env:
           # Pass the environment variable from GitHub to the test process
           NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}


### PR DESCRIPTION
The `playwright install` step was hanging in CI immediately after the Chromium binary finished downloading (100% in ~1s, then a stall until the job timeout) — a post-download installer deadlock tied to a runner environment change, since the same Playwright 1.58.2 + browser binary ran green in May.

Run the job inside mcr.microsoft.com/playwright:v1.58.2-noble, which ships the browsers and system dependencies pre-installed. This removes the download/install step entirely, so there is nothing left to hang, and pins the browser build to the image tag.

Keep the image tag in sync with the @playwright/test version.